### PR TITLE
Fixes #12

### DIFF
--- a/svg/SVG.pas
+++ b/svg/SVG.pas
@@ -3100,7 +3100,7 @@ var
 begin
   inherited;
 
-  FPath := TGPGraphicsPath2.Create;
+  FPath := TGPGraphicsPath2.Create(FillModeWinding);
   for C := 0 to Count - 1 do
   begin
     Element := TSVGPathElement(Items[C]);

--- a/svg/SVGPath.pas
+++ b/svg/SVGPath.pas
@@ -175,6 +175,8 @@ end;
 
 function TSVGPathMove.GetBounds: TRectF;
 begin
+  Result.Left := 0;
+  Result.Top := 0;
   Result.Width := 0;
   Result.Height := 0;
 end;
@@ -654,6 +656,8 @@ end;
 
 function TSVGPathClose.GetBounds: TRectF;
 begin
+  Result.Left := 0;
+  Result.Top := 0;
   Result.Width := 0;
   Result.Height := 0;
 end;


### PR DESCRIPTION
### Example
```svg
<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
  <path d="M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z
           m0 16H3V5h10v4h8v10z m2-16H1v18h22V3z m-2 16H3V5h10v4h8v10z"/>
</svg>
```
### Fix result
![delphi-svg- 12-fix](https://user-images.githubusercontent.com/14204888/51324851-2bd71800-1a85-11e9-8850-df516386e407.png)