### PR TITLE
Fixed infinite loop when loading SVG

### DIFF
--- a/svg/SVG.pas
+++ b/svg/SVG.pas
@@ -2739,7 +2739,8 @@ begin
     while Assigned(Child) do
     begin
       TSVGUse(Child).Construct;
-      Child := SVG.FindByType(TSVGUse);
+      //Child := SVG.FindByType(TSVGUse); - infinite loop was here
+      Child := SVG.FindByType(TSVGUse, Child);
     end;
   end;
 end;


### PR DESCRIPTION
When loading SVG there was an infinite loop in TSVGUse.Construct().
FindByType() was called inside the while() cycle without previous found item.